### PR TITLE
make_fat32_compatible: Remove double quotes

### DIFF
--- a/utils/patternparser.cpp
+++ b/utils/patternparser.cpp
@@ -373,6 +373,7 @@ const QString SaxHandler::make_fat32_compatible(const QString& string) {
   s.replace(":", "_");
   s.replace("*", "_");
   s.replace("?", "_");
+  s.replace("\"", "_");
   s.replace("<", "_");
   s.replace(">", "_");
   s.replace("|", "_");


### PR DESCRIPTION
Fixes the encoder failing on FAT32 compatible file names with double quotes.
