### PR TITLE
Move from Google (free search removed) to Bing for fetching cover art.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.cproject
+.kdev4/
+.project
+.settings/
+audex.kdev4
+build/

--- a/audex.kcfg
+++ b/audex.kcfg
@@ -28,8 +28,11 @@
       <default>true</default>
     </entry>
     <entry name="coverLookupAuto" type="Bool">
-      <label>Perform cover lookup (amazon) automatically</label>
-      <default>true</default>
+      <label>Perform cover lookup (Bing) automatically</label>
+      <default>false</default>
+    </entry>
+    <entry name="bingApiKey" type="String">
+      <label>Bing search developer API key</label>
     </entry>
     <entry name="wikipediaLocale" type="Int">
       <label>Wikipedia localization</label>

--- a/dialogs/coverbrowserdialog.cpp
+++ b/dialogs/coverbrowserdialog.cpp
@@ -101,7 +101,7 @@ void CoverBrowserDialog::setup() {
 
   setMainWidget(widget);
 
-  setCaption(i18n("Fetch Cover From Google"));
+  setCaption(i18n("Fetch Cover From Bing"));
   setButtons(KDialog::Ok | KDialog::Cancel);
 
   connect(&cover_fetcher, SIGNAL(fetchedThumbnail(const QByteArray&, const QString&, int)), this, SLOT(add_item(const QByteArray&, const QString&, int)));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -216,7 +216,7 @@ void MainWindow::cddb_lookup_done(const bool successful) {
   }
   update_layout();
   disable_submit();
-  if (Preferences::coverLookupAuto()) cdda_header_widget->googleAuto();
+  if (Preferences::coverLookupAuto()) cdda_header_widget->bingAuto();
 }
 
 void MainWindow::update_layout() {

--- a/utils/coverfetcher.h
+++ b/utils/coverfetcher.h
@@ -28,7 +28,10 @@
 #include <KUrl>
 #include <KIO/Job>
 #include <KIO/SimpleJob>
+#include <KIO/StoredTransferJob>
 #include <KIO/TransferJob>
+
+#include "preferences.h"
 
 class CoverFetcher : public QObject {
   Q_OBJECT
@@ -42,7 +45,6 @@ public:
   
   const QByteArray thumbnail(int index);
   const QString caption(int index);
-  const QString tbnid(int index);
   inline int count() { return cover_names.count(); }
 
   enum Status {
@@ -69,14 +71,12 @@ signals:
 
 private slots:
   void fetched_html_data(KJob* job);
-  void fetched_external_ip(KJob* job);
 
 private:
   int fetch_no;
   QStringList cover_urls_thumbnails;
   QStringList cover_urls;
   QStringList cover_names;
-  QStringList cover_tbnids;
   QList<QByteArray> cover_thumbnails;
   void clear() { cover_thumbnails.clear(); }
 
@@ -88,7 +88,7 @@ private:
   QString external_ip;
   QString search_string;
 
-  void parse_html_response(const QString& html);
+  void parse_html_response(const QString& json);
   bool fetch_cover_thumbnail();
   bool fetch_cover(const int no);
 

--- a/widgets/cddaheaderwidget.cpp
+++ b/widgets/cddaheaderwidget.cpp
@@ -385,11 +385,11 @@ void CDDAHeaderWidget::setEnabled(bool enabled) {
   repaint();
 }
 
-void CDDAHeaderWidget::googleAuto() {
+void CDDAHeaderWidget::bingAuto() {
 
-  kDebug() << "Google AUTO cover fetch" ;
+  kDebug() << "Bing AUTO cover fetch" ;
 
-  if ((cdda_model->empty()) || (fetching_cover_in_progress)) return;
+  if ((cdda_model->empty()) || (fetching_cover_in_progress) || Preferences::bingApiKey().trimmed().isEmpty()) return;
 
   QApplication::restoreOverrideCursor();
   cursor_on_cover = FALSE;
@@ -564,7 +564,7 @@ void CDDAHeaderWidget::mousePressEvent(QMouseEvent *event) {
 	if (cdda_model->empty()) {
 	  load();
 	} else {
-	  google();
+	  bing();
 	}
       } else {
 	view_cover();
@@ -652,9 +652,9 @@ void CDDAHeaderWidget::cover_is_down() {
   timer.start();
 }
 
-void CDDAHeaderWidget::google() {
+void CDDAHeaderWidget::bing() {
 
-  kDebug() << "Google cover fetch" ;
+  kDebug() << "Bing cover fetch" ;
 
   if ((cdda_model->empty()) || (fetching_cover_in_progress)) return;
 
@@ -777,7 +777,11 @@ void CDDAHeaderWidget::fetch_first_cover() {
   if (cover_browser_dialog) {
     if (cover_browser_dialog->count() == 0) {
       kDebug() << "no cover found";
-      ErrorDialog::show(this, i18n("No cover found."), i18n("Check your artist name and title. Otherwise you can load a custom cover from an image file."));
+      ErrorDialog::show(this,
+        i18n("No cover found."),
+        i18n("Check your artist name and title, otherwise you can load a custom cover from an image file.<br><br>"
+             "If you received an authentication dialog, check your Bing developer API key:<br>"
+             "<i>'Settings' >> 'Configure Audex...' >> 'General settings' >> 'Bing developer API key'</i> and/or try again later."));
       delete cover_browser_dialog;
       cover_browser_dialog = NULL;
       fetching_cover_in_progress = FALSE;
@@ -792,7 +796,11 @@ void CDDAHeaderWidget::fetch_first_cover() {
 void CDDAHeaderWidget::fetchCoverFinished(bool showDialog) {
   if (cover_browser_dialog) {
     if (showDialog) {
-      ErrorDialog::show(this, i18n("No cover found."), i18n("Check your artist name and title. Otherwise you can load a custom cover from an image file."));
+      ErrorDialog::show(this,
+        i18n("No cover found."),
+        i18n("Check your artist name and title, otherwise you can load a custom cover from an image file.<br><br>"
+             "If you received an authentication dialog, check your Bing developer API key:<br>"
+             "<i>'Settings' >> 'Configure Audex...' >> 'General settings' >> 'Bing developer API key'</i> and/or try again later."));
     }
     delete cover_browser_dialog;
     cover_browser_dialog = NULL;
@@ -833,9 +841,9 @@ void CDDAHeaderWidget::setup_actions() {
   action_collection = new KActionCollection(this);
 
   KAction* fetchCoverAction = new KAction(this);
-  fetchCoverAction->setText(i18n("Fetch cover from Google..."));
+  fetchCoverAction->setText(i18n("Fetch cover from Bing..."));
   action_collection->addAction("fetch", fetchCoverAction);
-  connect(fetchCoverAction, SIGNAL(triggered(bool)), this, SLOT(google()));
+  connect(fetchCoverAction, SIGNAL(triggered(bool)), this, SLOT(bing()));
 
   KAction* loadCoverAction = new KAction(this);
   loadCoverAction->setText(i18n("Set Custom Cover..."));

--- a/widgets/cddaheaderwidget.h
+++ b/widgets/cddaheaderwidget.h
@@ -88,7 +88,7 @@ public:
 public slots:
   void setEnabled(bool enabled);
 
-  void googleAuto();
+  void bingAuto();
 
 signals:
   void headerDataChanged();
@@ -109,7 +109,7 @@ private slots:
   void trigger_repaint();
   void cover_is_down();
 
-  void google();
+  void bing();
   void load();
   void save();
   void view_cover();

--- a/widgets/generalsettingswidgetUI.ui
+++ b/widgets/generalsettingswidgetUI.ui
@@ -53,6 +53,33 @@
        </widget>
       </item>
       <item row="5" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <widget class="QLabel" name="label_bingApiKey">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string><![CDATA[Bing <a href=https://datamarket.azure.com/dataset/bing/search>developer api</a> key:]]></string>
+          </property>
+          <property name="openExternalLinks">
+            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="kcfg_bingApiKey">
+          <property name="toolTip">
+           <string>Use the link to the left to obtain a Bing developer API key for free access to cover image lookups.</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="6" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QLabel" name="label">


### PR DESCRIPTION
Cover lookups in Audex have been broken since December 2015; Google have deprecated their free search API, so this change swaps out the Google-based cover lookup search for one that uses Bing.

This isn't absolutely ideal - it requires the user to register with Bing (any email address will do) to receive a free key to get 5000 free searches/month.  Once done though, cover art lookups become a reality again.

There's a small oddity in that the Bing search API only supports HTTP basic auth, and so a call without credentials/or with incorrect credentials leads to a pop-up.  There's an attempt to cover this in the error dialog text.

One plus point for the Bing search is that you're not limited on results returned - I've been using it for a little while and it seems OK.
